### PR TITLE
Kill processes with a specific cmd line parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Parameters
 
 * -a        : list all processes information from current processes snapshot.
 * -e [no]   : top [no] most expensive memory consuming processes | top 10 by default
-* -k        : kill specific process by PID
+* -k        : kill specific process by PID or name
+* --filter-param : filter processes to kill by command line substring (used with -k)
 * -o        : info only one process name criteria
 * -t [pid]  : tree snapshot of current processes or of the subprocesses of a specified process PID.
 * -d <name|pid> : process details with command line for matching process(es)
@@ -23,15 +24,16 @@ All the results can be redirected within a file.
 Usage examples.
 
 ```
-psa -t                                    // full snapshot tree
-psa -t 768                                // tree with the children processes of the process PID 768
-psa -o chrome                             // find how much memory uses your Chrome!   o_O
-psa -t > processes_tree.txt               // full snapshot tree redirection to a file
+psa -t                                                // full snapshot tree
+psa -t 768                                         // tree with the children processes of the process PID 768
+psa -o chrome                                 // find how much memory uses your Chrome!   o_O
+psa -t > processes_tree.txt              // full snapshot tree redirection to a file
 psa -e 20 > top_expensive_processes.txt   // top most 'expensive' processes and save information in a file
-psa -k notep                              // kill all the processs containing 'notep' within the process name
-psa -k 7891                               // kill the process having PID = 7891
-psa -d chrome                              // show details and command line for all processes matching 'chrome'
-psa -d 1234                                 // show details and command line for process with PID 1234
+psa -k notep                                    // kill all the processs containing 'notep' within the process name
+psa -k 7891                                       // kill the process having PID = 7891
+psa -k chrome --filter-param "network"         // kill all processes containing 'chrome' in name and 'network' in command line
+psa -d chrome                                 // show details and command line for all processes matching 'chrome'
+psa -d 1234                                      // show details and command line for process with PID 1234
 ```
 
 Compatibility

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -44,8 +44,8 @@ class string_utils {
   }
 
   [[nodiscard]] static bool search_substring(const ustring& str,
-                               const ustring& sub_str,
-                               bool case_insensitive = true) {
+                                             const ustring& sub_str,
+                                             bool case_insensitive = true) {
     if (case_insensitive) {
 #ifdef _WIN32
       ustring path2seach(str);
@@ -56,6 +56,9 @@ class string_utils {
                      toupper);
       return path2seach.find(str4seach) != ustring::npos;
 #else
+      // By design: Linux processes and system environments are case-sensitive
+      // by convention. We intentionally ignore the case sensitive flag here
+      // to enforce strict matching on Linux.
       return str.find(sub_str) != ustring::npos;  // no copies needed on Linux
 #endif
     }

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -23,11 +23,15 @@
 #include "operations.h"
 #include "pch.h"
 
+#include <cstdlib>
+#include <sstream>
 #include "fixed_queue.h"
-// RENAMED: process_actions
 #include "process_actions.h"
 #include "processes_tree_builder.h"
 #include "string_utils.h"
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 #ifdef _WIN32
 #include "smart_handler.h"
@@ -127,7 +131,6 @@ bool ProcessingOperations::BuildProcessesMap() {
   std::lock_guard<std::mutex> lock(map_mutex_);
 
 #ifdef _WIN32
-
   PROCESSENTRY32 pe32;
 
   smart_handle hProcessSnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
@@ -255,8 +258,8 @@ bool ProcessingOperations::get_filter_results(const ustring& process_name,
 
 bool ProcessingOperations::PrintAllProcessesInformation(
     bool const show_details) {
-  int processesCount = 0;
-  ULONG64 processesAllSize = 0;
+  int process_count = 0;
+  ULONG64 all_process_size = 0;
 
   if (!EnsureProcessesMap())
     return false;
@@ -269,12 +272,12 @@ bool ProcessingOperations::PrintAllProcessesInformation(
     if (show_details)
       static_cast<void>(PrintProcessDetailedInfo(proc.proc_pid));
 
-    processesAllSize += proc.used_memory;
-    processesCount++;
+    all_process_size += proc.used_memory;
+    process_count++;
   }
 
-  if (processesCount != 0) {
-    print_all_processes_summary(processesAllSize, processesCount);
+  if (process_count != 0) {
+    print_all_processes_summary(all_process_size, process_count);
   }
 
   return true;
@@ -282,8 +285,8 @@ bool ProcessingOperations::PrintAllProcessesInformation(
 
 bool ProcessingOperations::PrintProcessInformation(const ustring& filter,
                                                    bool const show_details) {
-  int processesCount = 0;
-  ULONG64 processesAllSize = 0;
+  int process_count = 0;
+  ULONG64 all_processes_size = 0;
 
   if (!EnsureProcessesMap())
     return false;
@@ -302,13 +305,13 @@ bool ProcessingOperations::PrintProcessInformation(const ustring& filter,
       print_process_details(proc);
     }
 
-    processesAllSize += proc.used_memory;
-    processesCount++;
+    all_processes_size += proc.used_memory;
+    process_count++;
   }
 
-  if (processesCount != 0) {
-    if (0 != processesAllSize) {
-      print_total_memory_summary(processesAllSize, processesCount);
+  if (process_count != 0) {
+    if (0 != all_processes_size) {
+      print_total_memory_summary(all_processes_size, process_count);
     } else {
       print_insufficient_privileges_message();
     }
@@ -371,6 +374,57 @@ void ProcessingOperations::KillProcesses(TCHAR const* argvProcessParam) {
   }
 }
 
+void ProcessingOperations::KillProcessesWithCmdLine(
+    const ustring& argv_process_param,
+    const ustring& cmdline_filter) {
+  if (argv_process_param.empty()) {
+    ucout << _T("Error: Process name or PID cannot be empty.") << std::endl;
+    return;
+  }
+  if (cmdline_filter.empty()) {
+    ucout << _T("Error: Command line filter cannot be empty.") << std::endl;
+    return;
+  }
+
+  if (!EnsureProcessesMap())
+    return;
+
+  std::vector<proc_info> candidates;
+  const bool filter_is_pid = string_utils::is_number(argv_process_param);
+
+  if (filter_is_pid) {
+    DWORD pid = static_cast<DWORD>(utoi(argv_process_param.c_str()));
+    auto range = map_processes_.equal_range(pid);
+    for (auto it = range.first; it != range.second; ++it) {
+      candidates.push_back(it->second);
+    }
+  } else {
+    for (const auto& [pid, proc] : map_processes_) {
+      if (string_utils::search_substring(proc.proc_name, argv_process_param)) {
+        candidates.push_back(proc);
+      }
+    }
+  }
+
+  std::vector<int> pids_to_kill;
+  for (const auto& proc : candidates) {
+    if (string_utils::search_substring(proc.cmdline_args, cmdline_filter)) {
+      pids_to_kill.push_back(proc.proc_pid);
+    }
+  }
+
+  if (pids_to_kill.empty()) {
+    ucout << _T("No processes matching '") << argv_process_param
+          << _T("' with command line containing '") << cmdline_filter
+          << _T("' were found.") << std::endl;
+    return;
+  }
+
+  for (int pid : pids_to_kill) {
+    process_actions::kill_process_by_pid_optimized(pid, map_processes_);
+  }
+}
+
 #ifdef _WIN32
 SIZE_T ProcessingOperations::GetProcessUsedMemory(DWORD const processID) const {
   smart_handle hProcess = OpenProcess(
@@ -421,24 +475,24 @@ BOOL ProcessingOperations::SetPrivilege(HANDLE hToken,
 }
 
 void ProcessingOperations::PrintError(const TCHAR* msg) {
-  DWORD eNum;
-  TCHAR sysMsg[256];
+  DWORD num;
+  TCHAR sys_msg[256];
   TCHAR* p;
 
-  eNum = GetLastError();
+  num = GetLastError();
   FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                NULL, eNum, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), sysMsg,
+                NULL, num, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), sys_msg,
                 256, NULL);
 
   // Trim trailing punctuation/newline from the system message.
-  p = sysMsg;
+  p = sys_msg;
   while ((*p > 31) || (*p == 9))
     ++p;
   do {
     *p-- = 0;
-  } while ((p >= sysMsg) && ((*p == '.') || (*p < 33)));
+  } while ((p >= sys_msg) && ((*p == '.') || (*p < 33)));
 
   ucout << std::format(_T("\n  WARNING: {} failed with error {} ({})"), msg,
-                       eNum, sysMsg);
+                       num, sys_msg);
 }
 #endif

--- a/src/operations.h
+++ b/src/operations.h
@@ -41,6 +41,8 @@ class ProcessingOperations {
       bool const show_details = false);
   virtual void PrintTopExpensiveProcesses(const int top);
   virtual void KillProcesses(TCHAR const* argvProcessParam);
+  virtual void KillProcessesWithCmdLine(const ustring& argvProcessParam,
+                                        const ustring& cmdlineFilter);
   virtual void GenerateProcessesTree(int const proc_pid,
                                      bool print_header = false);
 

--- a/src/psa.cpp
+++ b/src/psa.cpp
@@ -28,6 +28,7 @@
 #include "psa_cli_parsing.h"
 
 void ShowAvailableInformation();
+void ShowParameters();
 static ustring to_ustring(const std::string& s);
 
 namespace {
@@ -51,7 +52,10 @@ cxxopts::Options create_options() {
       ("t,tree", "Tree snapshot of current processes",
        cxxopts::value<int>()->implicit_value("1"), "[pid]")
 #endif
-          ("h,help", "Show available options");
+          ("filter-param",
+           "Filter processes to kill by command line substring (used with -k)",
+           cxxopts::value<std::string>(),
+           "<value>")("h,help", "Show available options");
   return options;
 }
 
@@ -66,6 +70,10 @@ bool handle_filter_option(const cxxopts::ParseResult& result,
 
   const std::string& value = result[key].as<std::string>();
   if (cli_parsing::is_flag_like_value(value)) {
+    ucout << _T("Error: option -") << to_ustring(key)
+          << _T(" requires a non-flag value.") << std::endl
+          << _T("More information:") << std::endl;
+    ShowParameters();
     return false;
   }
 
@@ -91,11 +99,28 @@ bool handle_kill_option(const cxxopts::ParseResult& result,
 
   const std::string& value = result["k"].as<std::string>();
   if (cli_parsing::is_flag_like_value(value)) {
+    ucout << _T("Error: option -k requires a non-flag value.") << std::endl;
+    ucout << _T("More information:") << std::endl;
+    ShowParameters();
     return false;
   }
 
   const auto filter = to_ustring(value);
-  processing_operations->KillProcesses(filter.c_str());
+  if (result.count("filter-param")) {
+    const std::string& cmdline_val = result["filter-param"].as<std::string>();
+    if (cmdline_val.empty() || cli_parsing::is_flag_like_value(cmdline_val)) {
+      ucout << _T("Error: option --filter-param requires a non-empty, ")
+               _T("non-flag value.")
+            << std::endl;
+      ucout << _T("More information:") << std::endl;
+      ShowParameters();
+      return false;
+    }
+    const auto cmdline_filter = to_ustring(cmdline_val);
+    processing_operations->KillProcessesWithCmdLine(filter, cmdline_filter);
+  } else {
+    processing_operations->KillProcesses(filter.c_str());
+  }
   good_params = true;
   return true;
 }
@@ -117,6 +142,12 @@ void handle_entries_option(const cxxopts::ParseResult& result,
 
 bool dispatch_requested_options(const cxxopts::ParseResult& result,
                                 ProcessingOperations* processing_operations) {
+  if (result.count("filter-param") && !result.count("k")) {
+    ucout << _T("Error: --filter-param can only be used with -k.") << std::endl;
+    ShowParameters();
+    return false;
+  }
+
   bool good_params = false;
 
   if (result.count("a")) {
@@ -162,7 +193,9 @@ void ShowParameters() {
            _T("processes ")
            _T("| top 10 by default ")
         << std::endl;
-  ucout << _T("    -k <name|pid> : kill specific process by PID or name")
+  ucout << _T("    -k <name|pid> [--filter-param <value>] : kill specific ")
+           _T("process ")
+           _T("by PID or name, optionally filtering by command line parameter")
         << std::endl;
   ucout << _T("    -o <name|pid> : info only one process name criteria ")
         << std::endl;

--- a/testing/test_psa_cli/test_psa_cli.cpp
+++ b/testing/test_psa_cli/test_psa_cli.cpp
@@ -79,6 +79,7 @@ struct FakeProcessingOperations : ProcessingOperations {
     bool show_details = false;
     ustring str_arg;
     int int_arg = 0;
+    ustring cmdline_arg;
   };
 
   std::vector<Call> calls;
@@ -101,6 +102,12 @@ struct FakeProcessingOperations : ProcessingOperations {
 
   void KillProcesses(TCHAR const* argvProcessParam) override {
     calls.push_back({"KillProcesses", false, ustring(argvProcessParam)});
+  }
+
+  void KillProcessesWithCmdLine(const ustring& argvProcessParam,
+                                const ustring& cmdlineFilter) override {
+    calls.push_back({"KillProcessesWithCmdLine", false, argvProcessParam, 0,
+                     cmdlineFilter});
   }
 
   void GenerateProcessesTree(int const proc_pid,
@@ -231,6 +238,36 @@ TEST_F(PsaCliTest, FlagKUpper_SameAsFlagK) {
   EXPECT_EQ(ustring(_T("notepad")), fake.calls[0].str_arg);
 }
 
+TEST_F(PsaCliTest, FlagK_WithFilterParam) {
+  Argv av{"psa", "-k", "chrome", "--filter-param", "network"};
+  EXPECT_TRUE(run(av));
+  ASSERT_EQ(1u, fake.calls.size());
+  EXPECT_EQ("KillProcessesWithCmdLine", fake.calls[0].name);
+  EXPECT_EQ(ustring(_T("chrome")), fake.calls[0].str_arg);
+  EXPECT_EQ(ustring(_T("network")), fake.calls[0].cmdline_arg);
+}
+
+TEST_F(PsaCliTest, FlagK_WithFilterParam_ByPid) {
+  Argv av{"psa", "-k", "1234", "--filter-param", "network"};
+  EXPECT_TRUE(run(av));
+  ASSERT_EQ(1u, fake.calls.size());
+  EXPECT_EQ("KillProcessesWithCmdLine", fake.calls[0].name);
+  EXPECT_EQ(ustring(_T("1234")), fake.calls[0].str_arg);
+  EXPECT_EQ(ustring(_T("network")), fake.calls[0].cmdline_arg);
+}
+
+TEST_F(PsaCliTest, FlagK_WithEmptyFilterParam_ReturnsFalse) {
+  Argv av{"psa", "-k", "chrome", "--filter-param", ""};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
+TEST_F(PsaCliTest, FilterParamWithoutK_ReturnsFalse) {
+  Argv av{"psa", "--filter-param", "network"};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
 // ===========================================================================
 // -o / -O  (print one process)
 // ===========================================================================
@@ -344,6 +381,12 @@ TEST_F(PsaCliTest, FlagK_FlagAsArg_ReturnsFalse) {
 
 TEST_F(PsaCliTest, FlagD_FlagAsArg_ReturnsFalse) {
   Argv av{"psa", "-d", "-a"};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
+TEST_F(PsaCliTest, FlagK_OptionAsArg_ReturnsFalse) {
+  Argv av{"psa", "-k", "--filter-param", "micro_av"};
   EXPECT_FALSE(run(av));
   EXPECT_TRUE(fake.calls.empty());
 }

--- a/testing/test_psa_cli/test_psa_cli_integration.cpp
+++ b/testing/test_psa_cli/test_psa_cli_integration.cpp
@@ -315,6 +315,37 @@ TEST_F(PsaCliIntegrationTest, FlagK_KillDummyProcess) {
   EXPECT_NE(exitCode, STILL_ACTIVE);
   CloseHandle(hProcess);
 }
+
+TEST_F(PsaCliIntegrationTest, FlagK_KillDummyProcessWithFilterParam) {
+  DWORD pid = 0;
+  HANDLE hProcess = spawn_dummy_process(pid);
+  ASSERT_NE(pid, 0u);
+  ASSERT_NE(hProcess, nullptr);
+  std::ostringstream ss;
+  ss << pid;
+  std::string pid_str = ss.str();
+  Argv av{"psa", "-k", pid_str.c_str(), "--filter-param", "ping"};
+  std::wstring out;
+  EXPECT_TRUE(run_and_capture(av, out));
+  std::wstring wpid;
+  for (char c : pid_str)
+    wpid += static_cast<wchar_t>(c);
+  EXPECT_NE(out.find(wpid), std::wstring::npos);
+  DWORD waitResult = WaitForSingleObject(hProcess, 2000);
+  EXPECT_TRUE(waitResult == WAIT_OBJECT_0);
+  DWORD exitCode = 0;
+  BOOL gotExit = GetExitCodeProcess(hProcess, &exitCode);
+  EXPECT_TRUE(gotExit);
+  EXPECT_NE(exitCode, STILL_ACTIVE);
+  CloseHandle(hProcess);
+}
+
+TEST_F(PsaCliIntegrationTest, FlagK_KillNonExistentProcessWithFilterParam) {
+  Argv av{"psa", "-k", "nonexistent_proc_xyz", "--filter-param", "nonexistent_val_abc"};
+  std::wstring out;
+  EXPECT_TRUE(run_and_capture(av, out));
+  EXPECT_NE(out.find(L"No processes matching 'nonexistent_proc_xyz' with command line containing 'nonexistent_val_abc' were found."), std::wstring::npos);
+}
 #else
 #include <signal.h>
 #include <sys/types.h>
@@ -342,5 +373,27 @@ TEST_F(PsaCliIntegrationTest, FlagK_KillDummyProcess) {
   // Confirm process is gone — kill(pid, 0) returns -1/ESRCH when not found
   EXPECT_EQ(kill(pid, 0), -1);
   waitpid(pid, nullptr, WNOHANG);
+}
+
+TEST_F(PsaCliIntegrationTest, FlagK_KillDummyProcessWithFilterParam) {
+  pid_t pid = spawn_dummy_process();
+  ASSERT_GT(pid, 0);
+  std::stringstream ss;
+  ss << pid;
+  std::string pid_str = ss.str();
+  Argv av{"psa", "-k", pid_str.c_str(), "--filter-param", "60"};
+  std::string out;
+  EXPECT_TRUE(run_and_capture(av, out));
+  EXPECT_NE(out.find(ss.str()), std::string::npos);
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_EQ(kill(pid, 0), -1);
+  waitpid(pid, nullptr, WNOHANG);
+}
+
+TEST_F(PsaCliIntegrationTest, FlagK_KillNonExistentProcessWithFilterParam) {
+  Argv av{"psa", "-k", "nonexistent_proc_xyz", "--filter-param", "nonexistent_val_abc"};
+  std::string out;
+  EXPECT_TRUE(run_and_capture(av, out));
+  EXPECT_NE(out.find("No processes matching 'nonexistent_proc_xyz' with command line containing 'nonexistent_val_abc' were found."), std::string::npos);
 }
 #endif


### PR DESCRIPTION
# Feature: Filtered Process Killing via `--filter-param`

## Overview
This PR introduces the new `--filter-param` option (used alongside `-k`), allowing users to kill processes by first matching a target `name`, but applying a filter overt the filter results over params by a specific substring within the process's command line arguments.

**Example Usage:**
```
psa -k chrome --filter-param "network"
# kills only the Chrome's network spawn process
# no worries, a new network process will be spawn by the first navigation
```