### PR TITLE
Unify -o and -d params into one single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Parameters
 * -e [no]   : top [no] most expensive memory consuming processes | top 10 by default
 * -k        : kill specific process by PID or name
 * --filter-param : filter processes to kill by command line substring (used with -k)
-* -o        : info only one process name criteria
+* -o        : info only one process name criteria (can be used with --details)
+* --details : show detailed process information (used with -o)
 * -t [pid]  : tree snapshot of current processes or of the subprocesses of a specified process PID.
-* -d <name|pid> : process details with command line for matching process(es)
 
 Usage
 ------------------------------------------
@@ -32,8 +32,8 @@ psa -e 20 > top_expensive_processes.txt   // top most 'expensive' processes and 
 psa -k notep                              // kill all the processs containing 'notep' within the process name
 psa -k 7891                               // kill the process having PID = 7891
 psa -k chrome --filter-param "network"    // kill all processes containing 'chrome' in name and 'network' in command line
-psa -d chrome                             // show details and command line for all processes matching 'chrome'
-psa -d 1234                               // show details and command line for process with PID 1234
+psa -o chrome --details                   // show details and command line for all processes matching 'chrome'
+psa -o 1234 --details                     // show details and command line for process with PID 1234
 ```
 
 Compatibility

--- a/src/psa.cpp
+++ b/src/psa.cpp
@@ -43,8 +43,7 @@ cxxopts::Options create_options() {
               cxxopts::value<std::string>(),
               "<name|pid>")("o", "Info for one process matching name criteria",
                             cxxopts::value<std::string>(), "<name|pid>")(
-      "d", "Process details with command line for matching process(es)",
-      cxxopts::value<std::string>(), "<name|pid>")
+      "details", "Show detailed process information (used with -o)")
 #ifdef _WIN32
       ("t,tree", "Tree snapshot of current processes",
        cxxopts::value<int>()->implicit_value("0"), "[pid]")
@@ -148,6 +147,12 @@ bool dispatch_requested_options(const cxxopts::ParseResult& result,
     return false;
   }
 
+  if (result.count("details") && !result.count("o")) {
+    ucout << _T("Error: --details can only be used with -o.") << std::endl;
+    ShowParameters();
+    return false;
+  }
+
   bool good_params = false;
 
   if (result.count("a")) {
@@ -162,12 +167,8 @@ bool dispatch_requested_options(const cxxopts::ParseResult& result,
     return false;
   }
 
-  if (!handle_filter_option(result, "o", false, processing_operations,
-                            good_params)) {
-    return false;
-  }
-
-  if (!handle_filter_option(result, "d", true, processing_operations,
+  const bool show_details = result.count("details") > 0;
+  if (!handle_filter_option(result, "o", show_details, processing_operations,
                             good_params)) {
     return false;
   }
@@ -197,11 +198,12 @@ void ShowParameters() {
            _T("process ")
            _T("by PID or name, optionally filtering by command line parameter")
         << std::endl;
-  ucout << _T("    -o <name|pid> : info only one process name criteria ")
+  ucout << _T("    -o <name|pid> [--details] : info only one process name ")
+           _T("criteria, optionally with details ")
         << std::endl;
-  ucout << _T("    -d <name|pid> : process details with command line for ")
-           _T("matching process(es)")
-        << std::endl;
+  ucout
+      << _T("    --details : show detailed process information (used with -o)")
+      << std::endl;
   ucout << _T("    -t [pid] : tree snapshot of current processes") << std::endl;
   ucout << _T("    -h    : show available options") << std::endl;
 }

--- a/src/psa_cli_parsing.cpp
+++ b/src/psa_cli_parsing.cpp
@@ -85,6 +85,17 @@ std::vector<std::string> normalize_arguments(int argc, char* argv[]) {
     std::string argument = argv[i];
     normalize_windows_short_option(argument);
 
+    if (argument == "-o" && i + 2 < argc) {
+      std::string next_arg = argv[i + 1];
+      if (next_arg == "--details" && !is_flag_like_value(argv[i + 2])) {
+        cooked_storage.push_back("-o");
+        cooked_storage.push_back(argv[i + 2]);
+        cooked_storage.push_back("--details");
+        i += 2;
+        continue;
+      }
+    }
+
     if (should_expand_numeric_short_option(argument, i, argc, argv)) {
       cooked_storage.push_back(
           expand_numeric_short_option(argument, argv[i + 1]));

--- a/src/psa_cli_parsing.cpp
+++ b/src/psa_cli_parsing.cpp
@@ -41,7 +41,7 @@ bool is_all_digits(const char* value) {
 void normalize_windows_short_option(std::string& argument) {
 #ifdef _WIN32
   if (argument.size() == 2 && argument[0] == '-' &&
-      std::strchr("ADEKOT", argument[1])) {
+      std::strchr("AEKOT", argument[1])) {
     argument[1] = static_cast<char>(tolower(argument[1]));
   }
 #else

--- a/testing/test_psa_cli/test_psa_cli.cpp
+++ b/testing/test_psa_cli/test_psa_cli.cpp
@@ -183,12 +183,7 @@ TEST_F(PsaCliTest, FlagO_ThenDetails_ThenValue_NormalizesAndSucceeds) {
 }
 
 TEST_F(PsaCliTest, DetailsWithoutO_ReturnsFalse) {
-  Argv av{"psa", "--details", "chrome"};
-  EXPECT_FALSE(run(av));
-  EXPECT_TRUE(fake.calls.empty());
-}
-
-TEST_F(PsaCliTest, DetailsAlone_ReturnsFalse) {
+  // --details is a boolean flag; without -o it must be rejected.
   Argv av{"psa", "--details"};
   EXPECT_FALSE(run(av));
   EXPECT_TRUE(fake.calls.empty());
@@ -198,6 +193,17 @@ TEST_F(PsaCliTest, FlagD_IsUnknownOption_ReturnsFalse) {
   Argv av{"psa", "-d", "chrome"};
   EXPECT_FALSE(run(av));
   EXPECT_TRUE(fake.calls.empty());
+}
+
+TEST_F(PsaCliTest, FlagO_WithDetails_AndFlagA_InvokesBoth) {
+  // -a and -o --details are independent; both operations should be dispatched.
+  Argv av{"psa", "-a", "-o", "chrome", "--details"};
+  EXPECT_TRUE(run(av));
+  ASSERT_EQ(2u, fake.calls.size());
+  EXPECT_EQ("PrintAll", fake.calls[0].name);
+  EXPECT_EQ("PrintOne", fake.calls[1].name);
+  EXPECT_TRUE(fake.calls[1].show_details);
+  EXPECT_EQ(ustring(_T("chrome")), fake.calls[1].str_arg);
 }
 
 // ===========================================================================
@@ -304,7 +310,23 @@ TEST_F(PsaCliTest, FlagOUpper_SameAsFlagO) {
   EXPECT_TRUE(run(av));
   ASSERT_EQ(1u, fake.calls.size());
   EXPECT_EQ("PrintOne", fake.calls[0].name);
+  EXPECT_FALSE(fake.calls[0].show_details);
   EXPECT_EQ(ustring(_T("svchost")), fake.calls[0].str_arg);
+}
+
+// Combined: -o <name> --details alongside -e still works; both operations run.
+TEST_F(PsaCliTest, FlagO_WithDetails_AndFlagE_BothRun) {
+  Argv av{"psa", "-o", "chrome", "--details", "-e", "5"};
+  EXPECT_TRUE(run(av));
+  ASSERT_EQ(2u, fake.calls.size());
+  // -e runs first (handle_entries_option order), then -o.
+  const auto& entries_call = fake.calls[0];
+  EXPECT_EQ("TopExpensive", entries_call.name);
+  EXPECT_EQ(5, entries_call.int_arg);
+  const auto& print_call = fake.calls[1];
+  EXPECT_EQ("PrintOne", print_call.name);
+  EXPECT_TRUE(print_call.show_details);
+  EXPECT_EQ(ustring(_T("chrome")), print_call.str_arg);
 }
 
 // ===========================================================================

--- a/testing/test_psa_cli/test_psa_cli.cpp
+++ b/testing/test_psa_cli/test_psa_cli.cpp
@@ -161,11 +161,11 @@ TEST_F(PsaCliTest, FlagAUpper_SameAsFlagA) {
 #endif
 
 // ===========================================================================
-// -d / -D  (print process details)
+// --details  (print process details)
 // ===========================================================================
 
-TEST_F(PsaCliTest, FlagD_PrintsWithDetails) {
-  Argv av{"psa", "-d", "chrome"};
+TEST_F(PsaCliTest, FlagDetails_PrintsWithDetails) {
+  Argv av{"psa", "-o", "chrome", "--details"};
   EXPECT_TRUE(run(av));
   ASSERT_EQ(1u, fake.calls.size());
   EXPECT_EQ("PrintOne", fake.calls[0].name);
@@ -173,13 +173,31 @@ TEST_F(PsaCliTest, FlagD_PrintsWithDetails) {
   EXPECT_EQ(ustring(_T("chrome")), fake.calls[0].str_arg);
 }
 
-TEST_F(PsaCliTest, FlagDUpper_SameAsFlagD) {
-  Argv av{"psa", "-D", "explorer"};
+TEST_F(PsaCliTest, FlagO_ThenDetails_ThenValue_NormalizesAndSucceeds) {
+  Argv av{"psa", "-o", "--details", "chrome"};
   EXPECT_TRUE(run(av));
   ASSERT_EQ(1u, fake.calls.size());
   EXPECT_EQ("PrintOne", fake.calls[0].name);
   EXPECT_TRUE(fake.calls[0].show_details);
-  EXPECT_EQ(ustring(_T("explorer")), fake.calls[0].str_arg);
+  EXPECT_EQ(ustring(_T("chrome")), fake.calls[0].str_arg);
+}
+
+TEST_F(PsaCliTest, DetailsWithoutO_ReturnsFalse) {
+  Argv av{"psa", "--details", "chrome"};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
+TEST_F(PsaCliTest, DetailsAlone_ReturnsFalse) {
+  Argv av{"psa", "--details"};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
+TEST_F(PsaCliTest, FlagD_IsUnknownOption_ReturnsFalse) {
+  Argv av{"psa", "-d", "chrome"};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
 }
 
 // ===========================================================================
@@ -345,7 +363,7 @@ TEST_F(PsaCliTest, PrintOne_FailurePropagated) {
 
 TEST_F(PsaCliTest, PrintDetails_FailurePropagated) {
   fake.return_value = false;
-  Argv av{"psa", "-d", "chrome"};
+  Argv av{"psa", "-o", "chrome", "--details"};
   EXPECT_FALSE(run(av));
 }
 
@@ -379,8 +397,8 @@ TEST_F(PsaCliTest, FlagK_FlagAsArg_ReturnsFalse) {
   EXPECT_TRUE(fake.calls.empty());
 }
 
-TEST_F(PsaCliTest, FlagD_FlagAsArg_ReturnsFalse) {
-  Argv av{"psa", "-d", "-a"};
+TEST_F(PsaCliTest, FlagDetails_FlagAsArg_ReturnsFalse) {
+  Argv av{"psa", "-o", "-a", "--details"};
   EXPECT_FALSE(run(av));
   EXPECT_TRUE(fake.calls.empty());
 }

--- a/testing/test_psa_cli/test_psa_cli_integration.cpp
+++ b/testing/test_psa_cli/test_psa_cli_integration.cpp
@@ -244,8 +244,8 @@ TEST_F(PsaCliIntegrationTest, FlagO_KnownProcess) {
 #endif
 }
 
-TEST_F(PsaCliIntegrationTest, FlagD_KnownProcess) {
-  Argv av{"psa", "-d", "System"};
+TEST_F(PsaCliIntegrationTest, FlagDetails_KnownProcess) {
+  Argv av{"psa", "-o", "System", "--details"};
 #ifdef _UNICODE
   std::wstring out;
   EXPECT_TRUE(run_and_capture(av, out));
@@ -341,10 +341,14 @@ TEST_F(PsaCliIntegrationTest, FlagK_KillDummyProcessWithFilterParam) {
 }
 
 TEST_F(PsaCliIntegrationTest, FlagK_KillNonExistentProcessWithFilterParam) {
-  Argv av{"psa", "-k", "nonexistent_proc_xyz", "--filter-param", "nonexistent_val_abc"};
+  Argv av{"psa", "-k", "nonexistent_proc_xyz", "--filter-param",
+          "nonexistent_val_abc"};
   std::wstring out;
   EXPECT_TRUE(run_and_capture(av, out));
-  EXPECT_NE(out.find(L"No processes matching 'nonexistent_proc_xyz' with command line containing 'nonexistent_val_abc' were found."), std::wstring::npos);
+  EXPECT_NE(
+      out.find(L"No processes matching 'nonexistent_proc_xyz' with command "
+               L"line containing 'nonexistent_val_abc' were found."),
+      std::wstring::npos);
 }
 #else
 #include <signal.h>
@@ -391,9 +395,13 @@ TEST_F(PsaCliIntegrationTest, FlagK_KillDummyProcessWithFilterParam) {
 }
 
 TEST_F(PsaCliIntegrationTest, FlagK_KillNonExistentProcessWithFilterParam) {
-  Argv av{"psa", "-k", "nonexistent_proc_xyz", "--filter-param", "nonexistent_val_abc"};
+  Argv av{"psa", "-k", "nonexistent_proc_xyz", "--filter-param",
+          "nonexistent_val_abc"};
   std::string out;
   EXPECT_TRUE(run_and_capture(av, out));
-  EXPECT_NE(out.find("No processes matching 'nonexistent_proc_xyz' with command line containing 'nonexistent_val_abc' were found."), std::string::npos);
+  EXPECT_NE(
+      out.find("No processes matching 'nonexistent_proc_xyz' with command line "
+               "containing 'nonexistent_val_abc' were found."),
+      std::string::npos);
 }
 #endif


### PR DESCRIPTION
# PR: Unite `-o` and `--details` Options

This PR combines the process info (`-o`) and process details (`-d`) options into a single unified syntax: `psa -o <name|pid> [--details]`. Standalone `-d` / `-D` options have been removed.

## Changes:
* **CLI Normalization**: Updated argument preprocessing to automatically normalize both `psa -o <name> --details` and `psa -o --details <name>` into the same format for the parser.
* **Option Rules**: Defined `--details` as a boolean flag. Added verification that rejects using `--details` without `-o`.
* **Documentation**: Updated usage examples and parameter ordering in `README.md`.
* **Tests**: Refactored mock unit tests and OS integration tests to cover the new `--details` validation and argument normalization rules.
