### PR TITLE
Identify Process Information by PID

### DIFF
--- a/include/general.h
+++ b/include/general.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <iostream>
 #include <map>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -144,6 +145,20 @@ struct proc_info {
   proc_info(proc_info&& rhs) noexcept = default;
 
   proc_info& operator=(proc_info&& rhs) noexcept = default;
+};
+
+struct proc_info_details : public proc_info {
+  ustring executable_path;
+  std::optional<ustring> parent_name;
+  std::optional<ustring> user;
+  std::optional<uint32_t> session_id;
+  std::optional<ustring> architecture;
+  std::optional<ustring> start_time;
+  std::optional<ustring> integrity_level;
+  std::optional<bool> elevated;
+
+  proc_info_details() = default;
+  explicit proc_info_details(const proc_info& base) : proc_info(base) {}
 };
 
 using procs_map = std::multimap<DWORD, proc_info>;

--- a/include/process_actions.h
+++ b/include/process_actions.h
@@ -38,19 +38,27 @@
 #include <signal.h>
 #include <unistd.h>
 #include <fstream>
+#include <fcntl.h>
+#include <pwd.h>
+#include <sys/stat.h>
+#include <sstream>
 #endif
 
 #define process_fake_name _T("_|_")
 
 namespace process_actions {
+[[nodiscard]] std::optional<proc_info_details> get_process_details_info(
+    const uint32_t pid);
+void print_process_info_report(const proc_info_details& details);
+
 void kill_process_by_name(const TCHAR* process_name);
 void kill_process_by_pid(const int process_pid);
 void kill_process_by_name_optimized(const TCHAR* process_name,
                                     const procs_map& map_processes);
 void kill_process_by_pid_optimized(const int process_pid,
                                    const procs_map& map_processes);
-ustring GetProcessPath(int process_pid);
-[[nodiscard]] ustring GetProcessCmdLine(int process_pid);
+[[nodiscard]] ustring get_process_path(const int process_pid);
+[[nodiscard]] ustring get_process_cmdline(const int process_pid);
 
 bool is_essential_proccess(const int process_pid);
 void execute_kill_process(const int process_pid, const TCHAR* process_name);

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -101,7 +101,7 @@ ustring resolve_process_details(const proc_info& process) {
     return process.cmdline_args;
   }
 
-  return process_actions::GetProcessCmdLine(process.proc_pid);
+  return process_actions::get_process_cmdline(process.proc_pid);
 }
 
 void print_process_details(const proc_info& process) {
@@ -111,7 +111,7 @@ void print_process_details(const proc_info& process) {
     return;
   }
 
-  const auto path = process_actions::GetProcessPath(process.proc_pid);
+  const auto path = process_actions::get_process_path(process.proc_pid);
   if (!path.empty()) {
     ucout << _T("   path: [ ") << path.c_str() << _T(" ]") << std::endl;
   }
@@ -154,7 +154,7 @@ bool ProcessingOperations::BuildProcessesMap() {
         pe32.th32ProcessID,
         proc_info(pe32.th32ProcessID, pe32.th32ParentProcessID, pe32.szExeFile,
                   GetProcessUsedMemory(pe32.th32ProcessID),
-                  process_actions::GetProcessCmdLine(pe32.th32ProcessID)));
+                  process_actions::get_process_cmdline(pe32.th32ProcessID)));
 
   } while (Process32Next(hProcessSnap, &pe32));
 
@@ -174,7 +174,7 @@ bool ProcessingOperations::BuildProcessesMap() {
         proc_info(_process.tid, _process.ppid,
                   (_process.cmdline != NULL) ? *_process.cmdline : _process.cmd,
                   _process.vsize,
-                  process_actions::GetProcessCmdLine(_process.tid)));
+                  process_actions::get_process_cmdline(_process.tid)));
   }
 
   closeproc(proc);
@@ -321,6 +321,16 @@ bool ProcessingOperations::PrintProcessInformation(const ustring& filter,
   }
 
   return true;
+}
+
+std::optional<proc_info_details> ProcessingOperations::GetProcessInfoByPid(
+    const uint32_t process_pid) {
+  return process_actions::get_process_details_info(process_pid);
+}
+
+void ProcessingOperations::PrintProcessInfoReport(
+    const proc_info_details& details) {
+  process_actions::print_process_info_report(details);
 }
 
 bool ProcessingOperations::PrintProcessDetailedInfo(DWORD pid) {

--- a/src/operations.h
+++ b/src/operations.h
@@ -39,6 +39,9 @@ class ProcessingOperations {
   [[nodiscard]] virtual bool PrintProcessInformation(
       const ustring& process_name,
       bool const show_details = false);
+  [[nodiscard]] virtual std::optional<proc_info_details> GetProcessInfoByPid(
+      const uint32_t process_pid);
+  virtual void PrintProcessInfoReport(const proc_info_details& details);
   virtual void PrintTopExpensiveProcesses(const int top);
   virtual void KillProcesses(TCHAR const* argvProcessParam);
   virtual void KillProcessesWithCmdLine(const ustring& argvProcessParam,

--- a/src/process_actions.cpp
+++ b/src/process_actions.cpp
@@ -26,6 +26,416 @@ namespace process_actions {
 
 namespace {
 
+#ifdef _WIN32
+using process_name_map = std::map<DWORD, ustring>;
+
+process_name_map build_process_name_map(HANDLE snapshot_handle) {
+  process_name_map names;
+
+  PROCESSENTRY32 entry{};
+  entry.dwSize = sizeof(entry);
+  if (!Process32First(snapshot_handle, &entry)) {
+    return names;
+  }
+
+  do {
+    names.emplace(entry.th32ProcessID, entry.szExeFile);
+  } while (Process32Next(snapshot_handle, &entry));
+
+  return names;
+}
+
+std::optional<proc_info_details> find_process_in_snapshot(
+    HANDLE snapshot_handle,
+    DWORD pid) {
+  PROCESSENTRY32 entry{};
+  entry.dwSize = sizeof(entry);
+  if (!Process32First(snapshot_handle, &entry)) {
+    return std::nullopt;
+  }
+
+  do {
+    if (entry.th32ProcessID == pid) {
+      proc_info_details details;
+      details.proc_pid = static_cast<int>(entry.th32ProcessID);
+      details.parent_pid = static_cast<int>(entry.th32ParentProcessID);
+      details.proc_name = entry.szExeFile;
+      return details;
+    }
+  } while (Process32Next(snapshot_handle, &entry));
+
+  return std::nullopt;
+}
+
+ustring format_system_time(const FILETIME& file_time) {
+  FILETIME local_file_time{};
+  SYSTEMTIME system_time{};
+
+  if (!FileTimeToLocalFileTime(&file_time, &local_file_time) ||
+      !FileTimeToSystemTime(&local_file_time, &system_time)) {
+    return _T("<unavailable>");
+  }
+
+  return std::format(_T("{:04}-{:02}-{:02} {:02}:{:02}:{:02}"),
+                     system_time.wYear, system_time.wMonth, system_time.wDay,
+                     system_time.wHour, system_time.wMinute,
+                     system_time.wSecond);
+}
+
+ustring query_process_architecture(HANDLE process_handle) {
+  SYSTEM_INFO system_info{};
+  GetNativeSystemInfo(&system_info);
+
+  BOOL is_wow64 = FALSE;
+  if (!IsWow64Process(process_handle, &is_wow64)) {
+    return _T("<unavailable>");
+  }
+
+  if (is_wow64) {
+    return _T("x86");
+  }
+
+  switch (system_info.wProcessorArchitecture) {
+    case PROCESSOR_ARCHITECTURE_AMD64:
+      return _T("x64");
+    case PROCESSOR_ARCHITECTURE_INTEL:
+      return _T("x86");
+    case PROCESSOR_ARCHITECTURE_ARM64:
+      return _T("ARM64");
+    case PROCESSOR_ARCHITECTURE_ARM:
+      return _T("ARM");
+    default:
+      return _T("<unavailable>");
+  }
+}
+
+std::optional<ustring> query_token_user(HANDLE token_handle) {
+  DWORD size = 0;
+  GetTokenInformation(token_handle, TokenUser, nullptr, 0, &size);
+  if (size == 0) {
+    return std::nullopt;
+  }
+
+  std::vector<BYTE> buffer(size);
+  if (!GetTokenInformation(token_handle, TokenUser, buffer.data(), size,
+                           &size)) {
+    return std::nullopt;
+  }
+
+  const auto* token_user = reinterpret_cast<const TOKEN_USER*>(buffer.data());
+
+  DWORD name_size = 0;
+  DWORD domain_size = 0;
+  SID_NAME_USE sid_type = SidTypeUnknown;
+  LookupAccountSidW(nullptr, token_user->User.Sid, nullptr, &name_size, nullptr,
+                    &domain_size, &sid_type);
+  if (name_size == 0) {
+    return std::nullopt;
+  }
+
+  std::wstring account_name(name_size, L'\0');
+  std::wstring domain_name(domain_size, L'\0');
+  if (!LookupAccountSidW(nullptr, token_user->User.Sid, account_name.data(),
+                         &name_size, domain_name.data(), &domain_size,
+                         &sid_type)) {
+    return std::nullopt;
+  }
+
+  account_name.resize(name_size);
+  domain_name.resize(domain_size);
+
+  if (!domain_name.empty()) {
+    return domain_name + _T("\\") + account_name;
+  }
+
+  return account_name;
+}
+
+std::optional<bool> query_token_elevation(HANDLE token_handle) {
+  TOKEN_ELEVATION elevation{};
+  DWORD size = 0;
+  if (!GetTokenInformation(token_handle, TokenElevation, &elevation,
+                           sizeof(elevation), &size)) {
+    return std::nullopt;
+  }
+
+  return elevation.TokenIsElevated != 0;
+}
+
+std::optional<ustring> query_token_integrity_level(HANDLE token_handle) {
+  DWORD size = 0;
+  GetTokenInformation(token_handle, TokenIntegrityLevel, nullptr, 0, &size);
+  if (size == 0) {
+    return std::nullopt;
+  }
+
+  std::vector<BYTE> buffer(size);
+  if (!GetTokenInformation(token_handle, TokenIntegrityLevel, buffer.data(),
+                           size, &size)) {
+    return std::nullopt;
+  }
+
+  const auto* mandatory_label =
+      reinterpret_cast<const TOKEN_MANDATORY_LABEL*>(buffer.data());
+  const DWORD rid = *GetSidSubAuthority(
+      mandatory_label->Label.Sid,
+      static_cast<DWORD>(*GetSidSubAuthorityCount(mandatory_label->Label.Sid) -
+                         1));
+
+  switch (rid) {
+    case SECURITY_MANDATORY_UNTRUSTED_RID:
+      return _T("Untrusted");
+    case SECURITY_MANDATORY_LOW_RID:
+      return _T("Low");
+    case SECURITY_MANDATORY_MEDIUM_RID:
+      return _T("Medium");
+    case SECURITY_MANDATORY_HIGH_RID:
+      return _T("High");
+    case SECURITY_MANDATORY_SYSTEM_RID:
+      return _T("System");
+    default:
+      return _T("<unavailable>");
+  }
+}
+
+void set_access_denied_fields(proc_info_details& details) {
+  details.executable_path = _T("<access denied>");
+  details.cmdline_args = _T("<access denied>");
+  details.architecture = _T("<access denied>");
+  details.start_time = _T("<access denied>");
+  details.integrity_level = _T("<access denied>");
+  details.user = _T("<access denied>");
+  details.session_id = std::nullopt;
+  details.elevated = std::nullopt;
+}
+
+std::optional<proc_info_details> get_process_details_info_win32(
+    const uint32_t pid) {
+  smart_handle snapshot_handle(CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0));
+  if (!snapshot_handle.get_handle() ||
+      snapshot_handle.get_handle() == INVALID_HANDLE_VALUE) {
+    return std::nullopt;
+  }
+
+  const auto names = build_process_name_map(snapshot_handle.get_handle());
+  auto details = find_process_in_snapshot(snapshot_handle.get_handle(),
+                                          static_cast<DWORD>(pid));
+  if (!details.has_value()) {
+    return std::nullopt;
+  }
+
+  const auto parent_it = names.find(static_cast<DWORD>(details->parent_pid));
+  if (parent_it != names.end()) {
+    details->parent_name = parent_it->second;
+  }
+
+  smart_handle process_handle(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
+                                          FALSE, static_cast<DWORD>(pid)));
+  if (!process_handle.get_handle()) {
+    if (GetLastError() == ERROR_ACCESS_DENIED) {
+      set_access_denied_fields(*details);
+    }
+    return details;
+  }
+
+  DWORD path_size = MAX_PATH;
+  std::vector<WCHAR> path_buffer(path_size + 1, L'\0');
+  if (QueryFullProcessImageNameW(process_handle.get_handle(), 0,
+                                 path_buffer.data(), &path_size)) {
+    details->executable_path.assign(path_buffer.data(), path_size);
+  } else {
+    details->executable_path = _T("<unavailable>");
+  }
+
+  details->cmdline_args = get_process_cmdline(static_cast<int>(pid));
+  if (details->cmdline_args.empty()) {
+    details->cmdline_args = _T("<unavailable>");
+  }
+
+  FILETIME create_time{};
+  FILETIME exit_time{};
+  FILETIME kernel_time{};
+  FILETIME user_time{};
+  if (GetProcessTimes(process_handle.get_handle(), &create_time, &exit_time,
+                      &kernel_time, &user_time)) {
+    details->start_time = format_system_time(create_time);
+  } else {
+    details->start_time = _T("<unavailable>");
+  }
+
+  DWORD session_id = 0;
+  if (ProcessIdToSessionId(static_cast<DWORD>(pid), &session_id)) {
+    details->session_id = session_id;
+  }
+
+  details->architecture =
+      query_process_architecture(process_handle.get_handle());
+
+  smart_handle token_handle(nullptr);
+  HANDLE token_raw = nullptr;
+  if (OpenProcessToken(process_handle.get_handle(), TOKEN_QUERY, &token_raw)) {
+    token_handle = smart_handle(token_raw);
+    details->user = query_token_user(token_handle.get_handle());
+    if (!details->user.has_value()) {
+      details->user = _T("<unavailable>");
+    }
+
+    details->elevated = query_token_elevation(token_handle.get_handle());
+    details->integrity_level =
+        query_token_integrity_level(token_handle.get_handle());
+  } else {
+    details->user = _T("<unavailable>");
+    details->elevated = std::nullopt;
+    details->integrity_level = _T("<unavailable>");
+  }
+
+  return details;
+}
+#endif  // _WIN32
+
+#ifndef _WIN32
+std::optional<proc_info_details> get_process_details_info_linux(
+    const uint32_t pid) {
+  const std::string proc_dir = std::format("/proc/{}", pid);
+  struct stat sb{};
+  if (stat(proc_dir.c_str(), &sb) != 0) {
+    return std::nullopt;
+  }
+
+  proc_info_details details;
+  details.proc_pid = static_cast<int>(pid);
+  details.executable_path = get_process_path(static_cast<int>(pid));
+
+  std::string comm_path = std::format("{}/comm", proc_dir);
+  std::ifstream comm_file(comm_path);
+  if (comm_file) {
+    std::string comm;
+    std::getline(comm_file, comm);
+    details.proc_name = comm;
+  }
+
+  details.cmdline_args = get_process_cmdline(static_cast<int>(pid));
+  if (details.cmdline_args.empty()) {
+    details.cmdline_args = _T("<unavailable>");
+  }
+
+  std::string status_path = std::format("{}/status", proc_dir);
+  std::ifstream status_file(status_path);
+  if (status_file) {
+    std::string line;
+    uint32_t uid = 0;
+    while (std::getline(status_file, line)) {
+      if (line.find("PPid:") == 0) {
+        std::sscanf(line.c_str(), "PPid:\t%d", &details.parent_pid);
+      } else if (line.find("Uid:") == 0) {
+        std::sscanf(line.c_str(), "Uid:\t%u", &uid);
+        details.user = std::to_string(uid);
+
+        struct passwd* pw = getpwuid(uid);
+        if (pw != nullptr) {
+          details.user = pw->pw_name;
+        }
+
+        details.elevated = (uid == 0);
+      }
+    }
+  }
+
+  std::string stat_path = std::format("{}/stat", proc_dir);
+  std::ifstream stat_file(stat_path);
+  if (stat_file) {
+    std::string line;
+    std::getline(stat_file, line);
+
+    size_t last_paren = line.rfind(')');
+    if (last_paren != std::string::npos) {
+      std::istringstream iss(line.substr(last_paren + 1));
+
+      char state = '\0';
+      int ppid = 0;
+      int pgrp = 0;
+      int session = 0;
+      int tty_nr = 0;
+      int tpgid = 0;
+      unsigned long flags = 0;
+      unsigned long minflt = 0;
+      unsigned long cminflt = 0;
+      unsigned long majflt = 0;
+      unsigned long cmajflt = 0;
+      unsigned long utime = 0;
+      unsigned long stime = 0;
+      long cutime = 0;
+      long cstime = 0;
+      long priority = 0;
+      long nice = 0;
+      long num_threads = 0;
+      long itrealvalue = 0;
+      unsigned long long starttime = 0;
+
+        if (!(iss >> state >> ppid >> pgrp >> session >> tty_nr >> tpgid >>
+          flags >> minflt >> cminflt >> majflt >> cmajflt >> utime >>
+          stime >> cutime >> cstime >> priority >> nice >> num_threads >>
+          itrealvalue >> starttime)) {
+        return details;
+        }
+
+      details.session_id = session;
+        details.parent_pid = ppid;
+
+      long clk_tck = sysconf(_SC_CLK_TCK);
+      if (clk_tck <= 0)
+        clk_tck = 100;
+
+      std::ifstream stat_info("/proc/stat");
+      unsigned long btime = 0;
+      if (stat_info) {
+        std::string stat_line;
+        while (std::getline(stat_info, stat_line)) {
+          if (stat_line.find("btime") == 0) {
+            std::sscanf(stat_line.c_str(), "btime %lu", &btime);
+            break;
+          }
+        }
+      }
+
+      if (btime > 0) {
+        time_t start_seconds = btime + (starttime / clk_tck);
+        struct tm* tm_info = localtime(&start_seconds);
+        if (tm_info != nullptr) {
+          char buffer[64];
+          strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", tm_info);
+          details.start_time = buffer;
+        }
+      }
+    }
+  }
+
+  int exe_fd = open(std::format("{}/exe", proc_dir).c_str(), O_RDONLY);
+  if (exe_fd >= 0) {
+    unsigned char elf_header[20];
+    if (read(exe_fd, elf_header, sizeof(elf_header)) == sizeof(elf_header)) {
+      if (elf_header[0] == 0x7f && elf_header[1] == 'E' &&
+          elf_header[2] == 'L' && elf_header[3] == 'F') {
+        unsigned char ei_class = elf_header[4];
+
+        if (ei_class == 1) {
+          details.architecture = _T("x86");
+        } else if (ei_class == 2) {
+          details.architecture = _T("x64");
+        } else {
+          details.architecture = _T("<unavailable>");
+        }
+      }
+    }
+    close(exe_fd);
+  }
+
+  details.integrity_level = std::nullopt;
+
+  return details;
+}
+#endif  // !_WIN32
+
 void print_termination_failure(const proc_info& process) {
   ucout << _T("Process '") << process.proc_name << _T("' PID [")
         << process.proc_pid << _T("] cannot be terminated.") << std::endl;
@@ -72,8 +482,7 @@ void print_missing_pid_message(int process_pid) {
 
 void print_missing_name_message(const TCHAR* process_name) {
   ucout << _T("No '") << process_name
-        << _T("' name or including this name pattern was found.")
-        << std::endl;
+        << _T("' name or including this name pattern was found.") << std::endl;
 }
 
 void kill_process_by_pid_optimized_impl(int process_pid,
@@ -130,12 +539,11 @@ void kill_process_by_pid_optimized(const int process_pid,
   execute_kill_process_optimized(process_pid, process_fake_name, map_processes);
 }
 
-ustring GetProcessPath(int process_pid) {
+ustring get_process_path(const int process_pid) {
   ustring process_path;
 #ifdef _WIN32
   smart_handle hnd(
-      OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
-                  FALSE, process_pid));
+      OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_pid));
   if (hnd.get_handle()) {
     DWORD dwSize = MAX_PATH;
     WCHAR szFileName[MAX_PATH] = {0};
@@ -155,11 +563,11 @@ ustring GetProcessPath(int process_pid) {
   return process_path;
 }
 
-ustring GetProcessCmdLine(int process_pid) {
+ustring get_process_cmdline(const int process_pid) {
   ustring cmdline;
 #ifdef _WIN32
-  smart_handle hnd(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
-                               FALSE, process_pid));
+  smart_handle hnd(
+      OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_pid));
   if (!hnd.get_handle())
     return cmdline;
   using NtQueryInformationProcess_t =
@@ -194,6 +602,59 @@ ustring GetProcessCmdLine(int process_pid) {
   cmdline = raw;
 #endif
   return cmdline;
+}
+
+std::optional<proc_info_details> get_process_details_info(const uint32_t pid) {
+#ifdef _WIN32
+  return get_process_details_info_win32(pid);
+#else
+  return get_process_details_info_linux(pid);
+#endif
+}
+
+void print_process_info_report(const proc_info_details& details) {
+  const auto format_optional_value =
+      [](const auto& opt,
+         const ustring& fallback =
+             _T(
+                                            "<unavailable>"))
+      -> ustring {
+    if (!opt.has_value()) {
+      return fallback;
+    }
+
+    using opt_type = std::remove_cvref_t<decltype(opt)>;
+    using value_t = typename opt_type::value_type;
+    if constexpr (std::is_same_v<value_t, bool>) {
+      return opt.value() ? _T("Yes") : _T("No");
+    } else if constexpr (std::is_integral_v<value_t>) {
+      return std::format(_T("{}"), opt.value());
+    } else {
+      return opt.value();
+    }
+  };
+
+  ucout << std::format(_T("{:<14}{}\n"), _T("PID:"), details.proc_pid);
+  ucout << std::format(_T("{:<14}{}\n"), _T("Name:"), details.proc_name);
+  ucout << std::format(_T("{:<14}{}\n"), _T("Parent PID:"), details.parent_pid);
+  ucout << std::format(_T("{:<14}{}\n"), _T("Parent Name:"),
+                       format_optional_value(details.parent_name));
+  ucout << std::format(_T("{:<14}{}\n"), _T("User:"),
+                       format_optional_value(details.user));
+  ucout << std::format(_T("{:<14}{}\n"), _T("Session ID:"),
+                       format_optional_value(details.session_id, _T("N/A")));
+  ucout << std::format(_T("{:<14}{}\n"), _T("Architecture:"),
+                       format_optional_value(details.architecture));
+  ucout << std::format(_T("{:<14}{}\n"), _T("Start Time:"),
+                       format_optional_value(details.start_time));
+  ucout << std::format(
+      _T("{:<14}{}\n"), _T("Integrity:"),
+      format_optional_value(details.integrity_level, _T("N/A")));
+  ucout << std::format(_T("{:<14}{}\n"), _T("Elevated:"),
+                       format_optional_value(details.elevated, _T("N/A")));
+  ucout << std::format(_T("{:<14}{}\n"), _T("Path:"), details.executable_path);
+  ucout << std::format(_T("{:<14}{}\n"), _T("Command Line:"),
+                       details.cmdline_args);
 }
 
 bool is_essential_proccess(const int process_pid) {

--- a/src/psa.cpp
+++ b/src/psa.cpp
@@ -33,6 +33,31 @@ static ustring to_ustring(const std::string& s);
 
 namespace {
 
+bool try_parse_positive_pid(const std::string& value, uint32_t& pid) {
+  if (value.empty()) {
+    return false;
+  }
+
+  uint64_t parsed = 0;
+  for (const unsigned char ch : value) {
+    if (!std::isdigit(ch)) {
+      return false;
+    }
+
+    parsed = (parsed * 10) + static_cast<uint64_t>(ch - '0');
+    if (parsed > static_cast<uint64_t>(UINT32_MAX)) {
+      return false;
+    }
+  }
+
+  if (parsed == 0) {
+    return false;
+  }
+
+  pid = static_cast<uint32_t>(parsed);
+  return true;
+}
+
 cxxopts::Options create_options() {
   cxxopts::Options options("psa", "Processes Status Analysis");
   options.add_options()("a", "List all processes information")(
@@ -43,7 +68,9 @@ cxxopts::Options create_options() {
               cxxopts::value<std::string>(),
               "<name|pid>")("o", "Info for one process matching name criteria",
                             cxxopts::value<std::string>(), "<name|pid>")(
-      "details", "Show detailed process information (used with -o)")
+      "pid", "Identify process information by PID",
+      cxxopts::value<std::string>(),
+      "<pid>")("details", "Show detailed process information (used with -o)")
 #ifdef _WIN32
       ("t,tree", "Tree snapshot of current processes",
        cxxopts::value<int>()->implicit_value("0"), "[pid]")
@@ -173,6 +200,25 @@ bool dispatch_requested_options(const cxxopts::ParseResult& result,
     return false;
   }
 
+  if (result.count("pid")) {
+    const std::string& pid_value = result["pid"].as<std::string>();
+    uint32_t pid = 0;
+    if (!try_parse_positive_pid(pid_value, pid)) {
+      ucout << _T("Error: PID must be a positive integer.") << std::endl;
+      return false;
+    }
+
+    auto details = processing_operations->GetProcessInfoByPid(pid);
+    if (!details.has_value()) {
+      ucout << _T("Error: Process with PID ") << pid << _T(" not found.")
+            << std::endl;
+      return false;
+    }
+
+    processing_operations->PrintProcessInfoReport(details.value());
+    good_params = true;
+  }
+
   if (result.count("t")) {
     processing_operations->GenerateProcessesTree(result["t"].as<int>());
     good_params = true;
@@ -200,6 +246,8 @@ void ShowParameters() {
         << std::endl;
   ucout << _T("    -o <name|pid> [--details] : info only one process name ")
            _T("criteria, optionally with details ")
+        << std::endl;
+  ucout << _T("    --pid <pid> : identify process information by PID")
         << std::endl;
   ucout
       << _T("    --details : show detailed process information (used with -o)")

--- a/testing/test_psa_cli/test_psa_cli.cpp
+++ b/testing/test_psa_cli/test_psa_cli.cpp
@@ -80,10 +80,12 @@ struct FakeProcessingOperations : ProcessingOperations {
     ustring str_arg;
     int int_arg = 0;
     ustring cmdline_arg;
+    uint32_t pid_arg = 0;
   };
 
   std::vector<Call> calls;
   bool return_value = true;
+  std::optional<proc_info_details> pid_lookup_result = std::nullopt;
 
   bool PrintAllProcessesInformation(bool const show_details = false) override {
     calls.push_back({"PrintAll", show_details});
@@ -110,6 +112,21 @@ struct FakeProcessingOperations : ProcessingOperations {
                      cmdlineFilter});
   }
 
+  std::optional<proc_info_details> GetProcessInfoByPid(
+      const uint32_t process_pid) override {
+    calls.push_back({"GetProcessInfoByPid", false, {}, 0, {}, process_pid});
+    return pid_lookup_result;
+  }
+
+  void PrintProcessInfoReport(const proc_info_details& details) override {
+    calls.push_back({"PrintProcessInfoReport",
+                     false,
+                     {},
+                     0,
+                     {},
+                     static_cast<uint32_t>(details.proc_pid)});
+  }
+
   void GenerateProcessesTree(int const proc_pid,
                              bool print_header = false) override {
     calls.push_back({"GenTree", print_header, {}, proc_pid});
@@ -126,6 +143,7 @@ class PsaCliTest : public ::testing::Test {
   void SetUp() override {
     fake.calls.clear();
     fake.return_value = true;
+    fake.pid_lookup_result = std::nullopt;
     optind = 0;  // Reset getopt state between tests.
     // XGetopt (Windows) uses a static `next` pointer that is only cleared
     // when optind == 0 at the start of a getopt() call.  Setting optind = 1
@@ -415,6 +433,71 @@ TEST_F(PsaCliTest, FlagO_FlagAsArg_ReturnsFalse) {
 
 TEST_F(PsaCliTest, FlagK_FlagAsArg_ReturnsFalse) {
   Argv av{"psa", "-k", "-a"};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
+// ===========================================================================
+// --pid  (process information by PID)
+// ===========================================================================
+
+TEST_F(PsaCliTest, FlagPid_ValidPositiveValue_CallsLookupAndPrintReport) {
+  proc_info_details details;
+  details.proc_pid = 1234;
+  details.proc_name = _T("dummy");
+  fake.pid_lookup_result = details;
+
+  Argv av{"psa", "--pid", "1234"};
+  EXPECT_TRUE(run(av));
+  ASSERT_EQ(2u, fake.calls.size());
+  EXPECT_EQ("GetProcessInfoByPid", fake.calls[0].name);
+  EXPECT_EQ(1234u, fake.calls[0].pid_arg);
+  EXPECT_EQ("PrintProcessInfoReport", fake.calls[1].name);
+  EXPECT_EQ(1234u, fake.calls[1].pid_arg);
+}
+
+TEST_F(PsaCliTest, FlagPid_NotFound_ReturnsFalse) {
+  fake.pid_lookup_result = std::nullopt;
+
+  Argv av{"psa", "--pid", "999999"};
+  EXPECT_FALSE(run(av));
+  ASSERT_EQ(1u, fake.calls.size());
+  EXPECT_EQ("GetProcessInfoByPid", fake.calls[0].name);
+  EXPECT_EQ(999999u, fake.calls[0].pid_arg);
+}
+
+TEST_F(PsaCliTest, FlagPid_InvalidAlpha_ReturnsFalse) {
+  Argv av{"psa", "--pid", "abc"};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
+TEST_F(PsaCliTest, FlagPid_InvalidNegative_ReturnsFalse) {
+  Argv av{"psa", "--pid", "-1"};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
+TEST_F(PsaCliTest, FlagPid_InvalidZero_ReturnsFalse) {
+  Argv av{"psa", "--pid", "0"};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
+TEST_F(PsaCliTest, FlagPid_InvalidTrailingSpace_ReturnsFalse) {
+  Argv av{"psa", "--pid", "1234 "};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
+TEST_F(PsaCliTest, FlagPid_InvalidOverflow_ReturnsFalse) {
+  Argv av{"psa", "--pid", "4294967296"};
+  EXPECT_FALSE(run(av));
+  EXPECT_TRUE(fake.calls.empty());
+}
+
+TEST_F(PsaCliTest, FlagPid_MissingArgument_ReturnsFalse) {
+  Argv av{"psa", "--pid"};
   EXPECT_FALSE(run(av));
   EXPECT_TRUE(fake.calls.empty());
 }

--- a/testing/test_psa_cli/test_psa_cli_integration.cpp
+++ b/testing/test_psa_cli/test_psa_cli_integration.cpp
@@ -274,6 +274,58 @@ TEST_F(PsaCliIntegrationTest, FlagT_TreeSnapshot) {
 #endif
 }
 
+TEST_F(PsaCliIntegrationTest, FlagPid_CurrentProcess_PrintsProcessReport) {
+#ifdef _WIN32
+  const uint32_t current_pid = static_cast<uint32_t>(GetCurrentProcessId());
+#else
+  const uint32_t current_pid = static_cast<uint32_t>(getpid());
+#endif
+
+  const std::string pid_str = std::to_string(current_pid);
+  Argv av{"psa", "--pid", pid_str.c_str()};
+
+#ifdef _UNICODE
+  std::wstring out;
+  EXPECT_TRUE(run_and_capture(av, out));
+  EXPECT_FALSE(out.empty());
+  EXPECT_NE(out.find(L"PID:"), std::wstring::npos);
+  EXPECT_NE(out.find(L"Name:"), std::wstring::npos);
+  EXPECT_NE(out.find(L"Path:"), std::wstring::npos);
+  EXPECT_NE(out.find(L"Command Line:"), std::wstring::npos);
+
+  std::wstring wpid;
+  for (char c : pid_str) {
+    wpid += static_cast<wchar_t>(c);
+  }
+  EXPECT_NE(out.find(wpid), std::wstring::npos);
+#else
+  std::string out;
+  EXPECT_TRUE(run_and_capture(av, out));
+  EXPECT_FALSE(out.empty());
+  EXPECT_NE(out.find("PID:"), std::string::npos);
+  EXPECT_NE(out.find("Name:"), std::string::npos);
+  EXPECT_NE(out.find("Path:"), std::string::npos);
+  EXPECT_NE(out.find("Command Line:"), std::string::npos);
+  EXPECT_NE(out.find(pid_str), std::string::npos);
+#endif
+}
+
+TEST_F(PsaCliIntegrationTest, FlagPid_NonexistentProcess_ReturnsFalseAndError) {
+  Argv av{"psa", "--pid", "4294967295"};
+
+#ifdef _UNICODE
+  std::wstring out;
+  EXPECT_FALSE(run_and_capture(av, out));
+  EXPECT_NE(out.find(L"Error: Process with PID 4294967295 not found."),
+            std::wstring::npos);
+#else
+  std::string out;
+  EXPECT_FALSE(run_and_capture(av, out));
+  EXPECT_NE(out.find("Error: Process with PID 4294967295 not found."),
+            std::string::npos);
+#endif
+}
+
 #ifdef _WIN32
 static HANDLE spawn_dummy_process(DWORD& pid) {
   STARTUPINFOW si = {sizeof(si)};


### PR DESCRIPTION
## PR Summary

Implemented and validated Step 6 for the new PID-based process info flow.

### What was completed

- Added unit tests for CLI parsing and validation of the --pid option in test_psa_cli.cpp.
- Added integration tests for end-to-end PID lookup behavior in test_psa_cli_integration.cpp.
- Confirmed the process report formatter (Step 5) was already implemented in process_actions.cpp.

### Test coverage added

- Valid positive PID path.
- Invalid PID values:
  - alphabetic
  - negative
  - zero
  - trailing space
  - overflow
- Missing PID argument.
- PID not found behavior.
- Integration path for current process PID and report rendering.
- Integration path for non-existent PID with expected error message.

### Validation results

- Rebuilt Debug binaries.
- Executed CTest for Debug configuration.
- Result: 75/75 tests passed.

## Planned Output Example

Example of the report format produced by the implemented formatter for --pid <pid>:

```text
PID:          1234
Name:         psa.exe
Parent PID:   567
Parent Name:  cmd.exe
User:         DOMAIN\User
Session ID:   1
Architecture: x64
Start Time:   2026-06-01 10:22:31
Integrity:    Medium
Elevated:     No
Path:         C:\tools\psa.exe
Command Line: psa.exe --pid 1234
```

And when a process is missing:

```text
Error: Process with PID 4294967295 not found.
```